### PR TITLE
Update penis.js: Fixed typo

### DIFF
--- a/src/penis.js
+++ b/src/penis.js
@@ -1,6 +1,6 @@
 /**
 
-The Giant Penis License (GLP)
+The Giant Penis License (GPL)
 
 Copyright (c) 2013 Edan Kwan
 


### PR DESCRIPTION
The file stated "The Giant Penis License (GLP)", which is a typo. It should be GPL.
